### PR TITLE
Fix: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

### DIFF
--- a/lib/iguvium.rb
+++ b/lib/iguvium.rb
@@ -73,7 +73,7 @@ module Iguvium
         opts[:gspath] ||= gs_nix?
       end
 
-      PDF::Reader.new(path, opts).pages.map { |page| Page.new(page, path, opts) }
+      PDF::Reader.new(path, opts).pages.map { |page| Page.new(page, path, **opts) }
     end
 
     # Creates and gives access to Ruby Logger. Default [Logger::Level] is Logger::ERROR.

--- a/lib/iguvium/image.rb
+++ b/lib/iguvium/image.rb
@@ -15,7 +15,6 @@ module Iguvium
     #
     # @return [ChunkyPNG::Image]
     def self.read(path, pagenumber = 1, **opts)
-      puts path.shellescape
       rgb = path.gsub(/\.pdf$/, '.rgb')
       Iguvium.logger.info `#{opts[:gspath]} -dSAFER -dBATCH -dNOPAUSE -sDEVICE=pnggray -dGraphicsAlphaBits=4 \
     -r72 -dFirstPage=#{pagenumber} -dLastPage=#{pagenumber} \

--- a/lib/iguvium/page.rb
+++ b/lib/iguvium/page.rb
@@ -71,7 +71,7 @@ module Iguvium
     private
 
     def recognize!
-      image = Image.read(@path, @reader_page.number, @opts)
+      image = Image.read(@path, @reader_page.number, **@opts)
       recognized = CV.new(image).recognize
       @lines = recognized[:lines]
       @boxes = recognized[:boxes].reject { |box| box_empty?(box) }


### PR DESCRIPTION
First off: thanks for this gem. It helped me put together a little script real quick to solve my problem.

I'm using `ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin20]` and with this version I saw some warnings that I figured might be nice to fix:

```
iguvium/lib/iguvium.rb:76: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
iguvium/lib/iguvium/page.rb:17: warning: The called method `initialize' is defined here
iguvium/lib/iguvium/page.rb:74: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
iguvium/lib/iguvium/image.rb:17: warning: The called method `read' is defined here
```

I don't do much Ruby these days but I read this blog post: https://bloggie.io/@kinopyo/how-to-fix-ruby-2-7-warning-using-the-last-argument-as-keyword-parameters-is-deprecated and fixed them as suggested.

I also removed a puts that would output the input filename since my script relied on piping stdout and it would pop up in my output.
Running the tests on this PR and master produces the same number of failures (3 on my machine) so I don't think any of those are related to the changes.