### PR TITLE
Solving deprecated use of keyword arguments in method calls

### DIFF
--- a/exe/iguvium
+++ b/exe/iguvium
@@ -30,7 +30,7 @@ abort('No file name given') unless path
 opts = opts.to_hash
 page_numbers = opts.delete(:pages).map { |number| number.to_i - 1 }
 
-pages = Iguvium.read(path, opts)
+pages = Iguvium.read(path, **opts)
 
 Iguvium.logger.level = Logger::INFO if opts[:verbose]
 


### PR DESCRIPTION
This fix is a complement to #5